### PR TITLE
Fix aplicado en class-wc-openpay-gateway.php

### DIFF
--- a/class-wc-openpay-gateway.php
+++ b/class-wc-openpay-gateway.php
@@ -373,11 +373,10 @@ class WC_Openpay_Gateway extends WC_Payment_Gateway
     {
         $this->logger->info("[WC_Openpay_Gateway.process_payment start]");
 
-        $this->logger->info("[WC_Openpay_Gateway.process_payment => openpay_month_interest_free ]" . $_POST['openpay_month_interest_free']);
+        $this->logger->info("[WC_Openpay_Gateway.process_payment => openpay_month_interest_free ]" . ($_POST['openpay_month_interest_free'] ?? 'N/A'));
 
         $cvv = isset($_POST['openpay_card_cvc']) && $_POST['openpay_card_cvc'] ?: $_POST['openpay-card-cvc'];
         $openpay_save_card_auth = isset($_POST['openpay_save_card_auth']) ? $_POST['openpay_save_card_auth'] : null;
-        $openpay_payment_plan = isset($_POST['openpay_selected_installment']) ? $_POST['openpay_selected_installment'] : null;
         $openpay_has_interest_pe = isset($_POST['openpay_has_interest_pe']) ? $_POST['openpay_has_interest_pe'] : null;
 
         $openpay_token = $_POST['openpay_token'];
@@ -386,20 +385,35 @@ class WC_Openpay_Gateway extends WC_Payment_Gateway
         $openpay_selected_card = $_POST['openpay_selected_card'];
         $openpay_card_points_confirm = $_POST['openpay_card_points_confirm'];
 
-        if ($openpay_payment_plan != null) {
-            $this->logger->info("[WC_Openpay_Gateway.process_payment] => openpay_payment_plan " . json_encode($_POST['openpay_selected_installment']));
+        // Read installment value: Blocks checkout sends 'openpay_selected_installment',
+        // Classic checkout sends country-specific field names.
+        $openpay_payment_plan = null;
+
+        if (isset($_POST['openpay_selected_installment']) && $_POST['openpay_selected_installment'] > 0) {
+            // Blocks checkout path
+            $openpay_payment_plan = intval($_POST['openpay_selected_installment']);
+        } else {
+            // Classic checkout path: read from country-specific field
             switch ($this->country) {
                 case 'MX':
-                    $openpay_payment_plan = $_POST['openpay_month_interest_free'];
+                    if (isset($_POST['openpay_month_interest_free']) && $_POST['openpay_month_interest_free'] > 1) {
+                        $openpay_payment_plan = intval($_POST['openpay_month_interest_free']);
+                    }
                     break;
                 case 'CO':
-                    $openpay_payment_plan = $_POST['openpay_installments'];
+                    if (isset($_POST['openpay_installments']) && $_POST['openpay_installments'] > 1) {
+                        $openpay_payment_plan = intval($_POST['openpay_installments']);
+                    }
                     break;
                 case 'PE':
-                    $openpay_payment_plan = $_POST['openpay_installments_pe'];
+                    if (isset($_POST['openpay_installments_pe']) && $_POST['openpay_installments_pe'] > 1) {
+                        $openpay_payment_plan = intval($_POST['openpay_installments_pe']);
+                    }
                     break;
             }
         }
+
+        $this->logger->info("[WC_Openpay_Gateway.process_payment] => openpay_payment_plan " . json_encode($openpay_payment_plan));
 
         $this->logger->info('[WC_Openpay_Gateway.process_payment] => openpay_tokenized_card ' . json_encode($openpay_tokenized_card));
 


### PR DESCRIPTION
Antes (bug):

// Linea 380: lee del campo blocks
$openpay_payment_plan = isset($_POST['openpay_selected_installment']) ? ... : null; // Linea 393: SOBREESCRIBE con campo clasico que NO existe en blocks → null $openpay_payment_plan = $_POST['openpay_month_interest_free'];

Despues (fix):

// Primero intenta campo blocks (openpay_selected_installment) if (isset($_POST['openpay_selected_installment']) && $_POST['openpay_selected_installment'] > 0) {
    $openpay_payment_plan = intval($_POST['openpay_selected_installment']);
} else {
    // Fallback: campo clasico segun pais
    switch ($this->country) {
        case 'MX': ... $_POST['openpay_month_interest_free'] ...
        case 'CO': ... $_POST['openpay_installments'] ...
        case 'PE': ... $_POST['openpay_installments_pe'] ...
    }
}